### PR TITLE
Fix deprecation warning from bs4

### DIFF
--- a/mkdocs_swagger_ui_tag/plugin.py
+++ b/mkdocs_swagger_ui_tag/plugin.py
@@ -292,7 +292,7 @@ class SwaggerUIPlugin(BasePlugin):
         iframe["style"] = "overflow:hidden;width:100%;"
         iframe["width"] = "100%"
         iframe["class"] = "swagger-ui-iframe"
-        swagger_ui_ele.replaceWith(iframe)
+        swagger_ui_ele.replace_with(iframe)
 
     def process_options(self, config, swagger_ui_ele):
         """Retrieve Swagger UI options from attribute and use config options as default"""


### PR DESCRIPTION
BS4 has changed the method `replaceWith` to `replace_with` and issued a deprecation for the old name.